### PR TITLE
Added LocalOnly() Class

### DIFF
--- a/enpyronments/utils.py
+++ b/enpyronments/utils.py
@@ -53,3 +53,15 @@ class Sensitive():
         """ Returns the masked value of the object (a str of asterisks with 
         length equal to ``self.stars``)"""
         return "*" * self.stars
+
+
+class LocalOnly():
+    """Raises a NotImplementedError unless the variable has been explicitly defined 
+    elsewhere. Useful for things like IP addresses that will be different in every enpyronment.
+    """
+
+    def __init__(self, name:str="No name specified"):
+        self.name = name
+
+    def __str__(self):
+        raise NotImplementedError(f"You must define this variable ({self.name}) in your *_local.py enpyronments file before it can be used!")


### PR DESCRIPTION
This class allows you to include variables in the main env files that
MUST be overridden in the local files before they can be used. This is
useful for things like IP addresses or domain names that will almost always 
be different across each environment.